### PR TITLE
hotfix/timescale

### DIFF
--- a/Assets/Scripts/PauseMenuController.cs
+++ b/Assets/Scripts/PauseMenuController.cs
@@ -13,6 +13,7 @@ public class PauseMenuController : MonoBehaviour
     {
         fpsController = GameObject.FindGameObjectWithTag("Player").GetComponent<Player_Movement>();
         fpsController.enabled = true;
+        Time.timeScale = 1f;
         menuButton.SetActive(false);
         Cursor.lockState = CursorLockMode.Locked;
         Cursor.visible = false;


### PR DESCRIPTION
fixed a bug where going back to the main menu and resetting the level didn't reenable the standard 1f timescale so the game would be frozen on loading back in.